### PR TITLE
added indexeddb support

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,78 @@
 document.addEventListener('DOMContentLoaded', function () {
-    // DOM Elements
+    // --- IndexedDB setup ---
+    const DB_NAME = 'calendarDB';
+    const DB_VERSION = 1;
+    let db = null;
+
+    function openDatabase() {
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_NAME, DB_VERSION);
+            request.onupgradeneeded = function (e) {
+                db = e.target.result;
+                if (!db.objectStoreNames.contains('events')) {
+                    db.createObjectStore('events', { keyPath: 'id' });
+                }
+                if (!db.objectStoreNames.contains('interpreters')) {
+                    db.createObjectStore('interpreters', { keyPath: 'id' });
+                }
+            };
+            request.onsuccess = function (e) {
+                db = e.target.result;
+                resolve();
+            };
+            request.onerror = function (e) {
+                reject(e);
+            };
+        });
+    }
+
+    function saveEvents(events) {
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('events', 'readwrite');
+            const store = tx.objectStore('events');
+            store.clear();
+            for (const event of events) {
+                store.put(event);
+            }
+            tx.oncomplete = () => resolve();
+            tx.onerror = e => reject(e);
+        });
+    }
+
+    function loadEvents() {
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('events', 'readonly');
+            const store = tx.objectStore('events');
+            const request = store.getAll();
+            request.onsuccess = () => resolve(request.result || []);
+            request.onerror = e => reject(e);
+        });
+    }
+
+    function saveInterpreters(interpreters) {
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('interpreters', 'readwrite');
+            const store = tx.objectStore('interpreters');
+            store.clear();
+            for (const interpreter of interpreters) {
+                store.put(interpreter);
+            }
+            tx.oncomplete = () => resolve();
+            tx.onerror = e => reject(e);
+        });
+    }
+
+    function loadInterpreters() {
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('interpreters', 'readonly');
+            const store = tx.objectStore('interpreters');
+            const request = store.getAll();
+            request.onsuccess = () => resolve(request.result || []);
+            request.onerror = e => reject(e);
+        });
+    }
+
+    // --- DOM Elements ---
     const elements = {
         calendar: document.getElementById('calendar'),
         monthSelector: document.getElementById('monthSelector'),
@@ -21,16 +94,16 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     };
 
-    // State
+    // --- State ---
     let events = [];
     let selectedEvents = [];
     let interpreters = [];
     let editingInterpreterId = null;
-    let selectingAssignedFor = null; // Tracks SEA edit mode
-    let assigningInterpreter = null; // Tracks assigning mode
-    let interpreterAssignments = {}; // Tracks working days: { interpreterId: { date: boolean } }
+    let selectingAssignedFor = null;
+    let assigningInterpreter = null;
+    let interpreterAssignments = {};
 
-    // Initialize FullCalendar
+    // --- FullCalendar ---
     const calendar = new FullCalendar.Calendar(elements.calendar, {
         initialView: 'dayGridMonth',
         events: [],
@@ -39,7 +112,6 @@ document.addEventListener('DOMContentLoaded', function () {
             const isSelected = selectedEvents.includes(eventId);
 
             if (isSelected) {
-                // Deselect event
                 selectedEvents = selectedEvents.filter(id => id !== eventId);
                 const event = events.find(e => e.id === eventId);
                 event.classNames = getEventClassNames(event);
@@ -50,7 +122,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 assigningInterpreter = null;
                 resetTickBoxes();
             } else {
-                // Select event
                 selectedEvents.push(eventId);
                 info.event.setProp('classNames', ['selected']);
                 assigningInterpreter = null;
@@ -85,7 +156,7 @@ document.addEventListener('DOMContentLoaded', function () {
             if (assigningInterpreter) {
                 let assignmentCount = 0;
                 events.forEach(event => {
-                    if (event.assigned.split(', ').filter(n => n).includes(assigningInterpreter.name)) {
+                    if ((event.interpreterIds || []).includes(assigningInterpreter.id)) {
                         const start = new Date(event.start);
                         start.setHours(0, 0, 0, 0);
                         const end = new Date(event.end || event.start);
@@ -96,14 +167,12 @@ document.addEventListener('DOMContentLoaded', function () {
                     }
                 });
 
-                // Apply highlight based on number of assignments
                 if (assignmentCount >= 2) {
                     classes.push('interpreter-overlap');
                 } else if (assignmentCount === 1) {
                     classes.push('interpreter-assigned');
                 }
 
-                // Highlight working days
                 const assignments = interpreterAssignments[assigningInterpreter.id] || {};
                 if (assignments[dateStr]) {
                     classes.push('working-day');
@@ -120,10 +189,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 tickbox.type = 'checkbox';
                 tickbox.className = 'date-tickbox';
                 tickbox.id = `tickbox-${dateStr}`;
-                tickbox.checked = false; // Default to unticked
+                tickbox.checked = false;
                 topElement.appendChild(tickbox);
 
-                // Tick box handler for assigning mode
                 tickbox.addEventListener('change', () => {
                     if (assigningInterpreter) {
                         const interpreterId = assigningInterpreter.id;
@@ -131,11 +199,10 @@ document.addEventListener('DOMContentLoaded', function () {
                             interpreterAssignments[interpreterId] = {};
                         }
                         interpreterAssignments[interpreterId][dateStr] = tickbox.checked;
-                        calendar.render(); // Update working-day highlight
+                        calendar.render();
                     }
                 });
 
-                // Initialize checked state for assigning mode
                 if (assigningInterpreter) {
                     const assignments = interpreterAssignments[assigningInterpreter.id] || {};
                     tickbox.checked = !!assignments[dateStr];
@@ -148,7 +215,6 @@ document.addEventListener('DOMContentLoaded', function () {
     });
     calendar.render();
 
-    // Reset tick boxes and clear working-day highlights
     function resetTickBoxes() {
         if (assigningInterpreter) {
             const interpreterId = assigningInterpreter.id;
@@ -160,7 +226,6 @@ document.addEventListener('DOMContentLoaded', function () {
         calendar.render();
     }
 
-    // Month selector
     elements.monthSelector.addEventListener('change', function () {
         const month = parseInt(this.value);
         calendar.gotoDate(new Date(calendar.getDate().getFullYear(), month, 1));
@@ -169,8 +234,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     elements.monthSelector.value = new Date().getMonth();
 
-    // Add event
-    elements.enterBtn.addEventListener('click', function () {
+    elements.enterBtn.addEventListener('click', async function () {
         const startDate = elements.inputs.startDate.value;
         const endDate = elements.inputs.endDate.value || startDate;
         const event = {
@@ -180,7 +244,8 @@ document.addEventListener('DOMContentLoaded', function () {
             end: new Date(new Date(endDate).setDate(new Date(endDate).getDate() + 1)).toISOString().split('T')[0],
             location: elements.inputs.location.value,
             interpreters: elements.inputs.interpreters.value || '0',
-            assigned: ''
+            assigned: '',
+            interpreterIds: [] // Store assigned interpreter ids for this event
         };
 
         if (!event.start || !event.title) {
@@ -196,52 +261,55 @@ document.addEventListener('DOMContentLoaded', function () {
         elements.inputs.location.value = 'Hong Kong';
         elements.inputs.interpreters.value = '';
 
+        await saveEvents(events);
+
         calendar.render();
     });
 
-    // Get event class names
     function getEventClassNames(event) {
         if (selectedEvents.includes(event.id)) return ['selected'];
-
-        const interpreters = parseInt(event.interpreters) || 0;
-        const assignedCount = event.assigned ? event.assigned.split(', ').filter(n => n).length : 0;
-        if (interpreters - assignedCount === 0 && event.assigned) {
+        const interpretersNeeded = parseInt(event.interpreters) || 0;
+        const assignedCount = (event.interpreterIds || []).length;
+        if (interpretersNeeded - assignedCount === 0 && assignedCount > 0) {
             return [event.location === 'Hong Kong' ? 'fully-assigned-hong-kong' : 'fully-assigned-macau'];
         }
         return [event.location.toLowerCase()];
     }
 
-    // Render selected events (SEA)
     function renderSelectedEvents() {
         elements.eventList.innerHTML = '';
         selectedEvents.forEach(eventId => {
             const event = events.find(e => e.id === eventId);
             if (!event) return;
 
-            const interpreters = parseInt(event.interpreters) || 0;
-            const assignedCount = event.assigned ? event.assigned.split(', ').filter(n => n).length : 0;
-            const interpretersLeft = interpreters - assignedCount;
+            const interpretersNeeded = parseInt(event.interpreters) || 0;
+            const assignedCount = (event.interpreterIds || []).length;
+            const interpretersLeft = interpretersNeeded - assignedCount;
 
             const row = document.createElement('div');
             row.className = 'event-row';
             row.dataset.id = eventId;
             row.innerHTML = `
-        <input type="text" data-field="title" value="${event.title}" class="p-2 border rounded w-32">
-        <select data-field="location" class="p-2 border rounded w-32">
-          <option value="Hong Kong" ${event.location === 'Hong Kong' ? 'selected' : ''}>Hong Kong</option>
-          <option value="Macau" ${event.location === 'Macau' ? 'selected' : ''}>Macau</option>
-        </select>
-        <input type="date" data-field="start" value="${event.start}" class="p-2 border rounded w-32">
-        <input type="date" data-field="end" value="${event.end ? new Date(new Date(event.end).setDate(new Date(event.end).getDate() - 1)).toISOString().split('T')[0] : ''}" class="p-2 border rounded w-32">
-        <input type="number" data-field="interpreters" value="${event.interpreters}" min="0" class="p-2 border rounded w-32">
-        <input type="number" data-field="interpretersLeft" value="${interpretersLeft}" class="p-2 border rounded w-32" readonly>
-        <input type="text" data-field="assigned" value="${event.assigned}" class="p-2 border rounded ${selectingAssignedFor && selectingAssignedFor.eventId === eventId ? 'editing' : ''}" ${selectingAssignedFor && selectingAssignedFor.eventId === eventId ? '' : 'readonly'}>
-        <button class="delete-icon" title="Delete Event">🗑️</button>
-      `;
+                <input type="text" data-field="title" value="${event.title}" class="p-2 border rounded w-32">
+                <select data-field="location" class="p-2 border rounded w-32">
+                  <option value="Hong Kong" ${event.location === 'Hong Kong' ? 'selected' : ''}>Hong Kong</option>
+                  <option value="Macau" ${event.location === 'Macau' ? 'selected' : ''}>Macau</option>
+                </select>
+                <input type="date" data-field="start" value="${event.start}" class="p-2 border rounded w-32">
+                <input type="date" data-field="end" value="${event.end ? new Date(new Date(event.end).setDate(new Date(event.end).getDate() - 1)).toISOString().split('T')[0] : ''}" class="p-2 border rounded w-32">
+                <input type="number" data-field="interpreters" value="${event.interpreters}" min="0" class="p-2 border rounded w-32">
+                <input type="number" data-field="interpretersLeft" value="${interpretersLeft}" class="p-2 border rounded w-32" readonly>
+                <button class="delete-icon" title="Delete Event">🗑️</button>
+                <div class="interpreter-list" style="margin-top: 8px;">
+                    <span style="font-size:0.95em;">Assigned Interpreters:</span>
+                    <div id="assigned-interpreters-${event.id}" class="assigned-interpreters-list"></div>
+                </div>
+            `;
 
-            const inputs = row.querySelectorAll('input:not([data-field="interpreters"],[data-field="interpretersLeft"],[data-field="assigned"]), select');
+            // Event field inputs
+            const inputs = row.querySelectorAll('input:not([data-field="interpreters"],[data-field="interpretersLeft"]), select');
             inputs.forEach(input => {
-                input.addEventListener('input', () => {
+                input.addEventListener('input', async () => {
                     event.title = row.querySelector('input[data-field="title"]').value || 'Untitled';
                     event.location = row.querySelector('select[data-field="location"]').value;
                     event.start = row.querySelector('input[data-field="start"]').value;
@@ -255,17 +323,19 @@ document.addEventListener('DOMContentLoaded', function () {
                         calendar.addEvent(event);
                     }
 
+                    await saveEvents(events);
                     renderSelectedEvents();
                     calendar.render();
                 });
             });
 
+            // Interpreters needed
             const interpretersInput = row.querySelector('input[data-field="interpreters"]');
-            interpretersInput.addEventListener('input', () => {
+            interpretersInput.addEventListener('input', async () => {
                 event.interpreters = interpretersInput.value || '0';
-                const interpreters = parseInt(event.interpreters) || 0;
-                const assignedCount = event.assigned ? event.assigned.split(', ').filter(n => n).length : 0;
-                row.querySelector('input[data-field="interpretersLeft"]').value = interpreters - assignedCount;
+                const interpretersNeeded = parseInt(event.interpreters) || 0;
+                const assignedCount = (event.interpreterIds || []).length;
+                row.querySelector('input[data-field="interpretersLeft"]').value = interpretersNeeded - assignedCount;
 
                 const calEvent = calendar.getEventById(eventId);
                 if (calEvent) {
@@ -274,70 +344,102 @@ document.addEventListener('DOMContentLoaded', function () {
                     calendar.addEvent(event);
                 }
 
+                await saveEvents(events);
                 renderSelectedEvents();
                 calendar.render();
             });
 
-            const assignedInput = row.querySelector('input[data-field="assigned"]');
-            assignedInput.addEventListener('click', () => {
-                if (selectingAssignedFor && selectingAssignedFor.eventId === eventId) {
-                    selectingAssignedFor = null;
-                    assignedInput.readOnly = true;
-                    assignedInput.classList.remove('editing');
-                } else {
-                    selectingAssignedFor = { eventId, input: assignedInput };
-                    assignedInput.readOnly = false;
-                    assignedInput.classList.add('editing');
-                    assigningInterpreter = null;
-                    resetTickBoxes();
-                }
-                renderSelectedEvents();
-                renderInterpreters();
-                calendar.render();
-            });
-
-            assignedInput.addEventListener('input', () => {
-                event.assigned = assignedInput.value;
-                const interpreters = parseInt(event.interpreters) || 0;
-                const assignedCount = event.assigned ? event.assigned.split(', ').filter(n => n).length : 0;
-                row.querySelector('input[data-field="interpretersLeft"]').value = interpreters - assignedCount;
-
-                const calEvent = calendar.getEventById(eventId);
-                if (calEvent) {
-                    calEvent.remove();
-                    event.classNames = getEventClassNames(event);
-                    calendar.addEvent(event);
-                }
-
-                renderSelectedEvents();
-                renderInterpreters();
-                calendar.render();
-            });
-
+            // Delete event
             const deleteButton = row.querySelector('.delete-icon');
-            deleteButton.addEventListener('click', () => {
+            deleteButton.addEventListener('click', async () => {
                 events = events.filter(e => e.id !== eventId);
                 const calEvent = calendar.getEventById(eventId);
-                if (calEvent) {
-                    calEvent.remove();
-                }
+                if (calEvent) calEvent.remove();
                 selectedEvents = selectedEvents.filter(id => id !== eventId);
-                if (selectingAssignedFor && selectingAssignedFor.eventId === eventId) {
-                    selectingAssignedFor = null;
-                }
+                if (selectingAssignedFor && selectingAssignedFor.eventId === eventId) selectingAssignedFor = null;
                 assigningInterpreter = null;
                 resetTickBoxes();
+                await saveEvents(events);
                 renderSelectedEvents();
                 renderInterpreters();
                 calendar.render();
             });
 
+            // Render assigned interpreters as removable chips
+            const assignedDiv = row.querySelector(`#assigned-interpreters-${event.id}`);
+            assignedDiv.innerHTML = '';
+            (event.interpreterIds || []).forEach(intId => {
+                const interpreter = interpreters.find(i => i.id === intId);
+                if (!interpreter) return;
+                const chip = document.createElement('span');
+                chip.className = 'assigned-chip';
+                chip.style = 'background:#dff0d8; margin-right:4px; padding:2px 7px; border-radius:12px; display:inline-block;';
+                chip.textContent = interpreter.name + ' ×';
+                chip.title = 'Remove';
+                chip.addEventListener('click', async () => {
+                    event.interpreterIds = event.interpreterIds.filter(id => id !== intId);
+                    const interpretersNeeded = parseInt(event.interpreters) || 0;
+                    const assignedCount = (event.interpreterIds || []).length;
+                    row.querySelector('input[data-field="interpretersLeft"]').value = interpretersNeeded - assignedCount;
+
+                    const calEvent = calendar.getEventById(eventId);
+                    if (calEvent) {
+                        calEvent.remove();
+                        event.classNames = getEventClassNames(event);
+                        calendar.addEvent(event);
+                    }
+
+                    await saveEvents(events);
+                    renderSelectedEvents();
+                    renderInterpreters();
+                    calendar.render();
+                });
+                assignedDiv.appendChild(chip);
+            });
+
+            // Show list of assignable interpreters only for selected events
+            if (selectedEvents.includes(eventId)) {
+                const assignDiv = document.createElement('div');
+                assignDiv.style = 'margin-top:5px;';
+                assignDiv.innerHTML = '<span style="font-size:0.9em">Add Interpreter:</span> ';
+                interpreters.forEach(interpreter => {
+                    const isAssigned = (event.interpreterIds || []).includes(interpreter.id);
+                    if (!isAssigned) {
+                        const btn = document.createElement('button');
+                        btn.textContent = interpreter.name;
+                        btn.className = 'assign-btn';
+                        btn.style = 'margin:2px 5px 2px 0; padding:1px 8px; font-size:0.9em;';
+                        btn.addEventListener('click', async () => {
+                            if (!event.interpreterIds.includes(interpreter.id)) {
+                                event.interpreterIds.push(interpreter.id);
+
+                                const interpretersNeeded = parseInt(event.interpreters) || 0;
+                                const assignedCount = (event.interpreterIds || []).length;
+                                row.querySelector('input[data-field="interpretersLeft"]').value = interpretersNeeded - assignedCount;
+
+                                const calEvent = calendar.getEventById(eventId);
+                                if (calEvent) {
+                                    calEvent.remove();
+                                    event.classNames = getEventClassNames(event);
+                                    calendar.addEvent(event);
+                                }
+
+                                await saveEvents(events);
+                                renderSelectedEvents();
+                                renderInterpreters();
+                                calendar.render();
+                            }
+                        });
+                        assignDiv.appendChild(btn);
+                    }
+                });
+                row.appendChild(assignDiv);
+            }
             elements.eventList.appendChild(row);
         });
     }
 
-    // Add interpreter
-    elements.intEnterBtn.addEventListener('click', function () {
+    elements.intEnterBtn.addEventListener('click', async function () {
         const interpreter = {
             id: editingInterpreterId || Date.now().toString(),
             name: elements.intInputs.name.value || 'Unnamed',
@@ -355,78 +457,69 @@ document.addEventListener('DOMContentLoaded', function () {
         Object.values(elements.intInputs).forEach(input => input.value = '');
         editingInterpreterId = null;
 
+        await saveInterpreters(interpreters);
+
         renderInterpreters();
         calendar.render();
     });
 
-    // Render interpreters
     function renderInterpreters() {
         elements.interpreterList.innerHTML = '';
         interpreters.forEach(interpreter => {
             const row = document.createElement('tr');
             row.dataset.id = interpreter.id;
 
-            const isSelected = selectingAssignedFor && events.find(e => e.id === selectingAssignedFor.eventId)?.assigned.split(', ').filter(n => n).includes(interpreter.name);
-            const isAssigned = assigningInterpreter && assigningInterpreter.name === interpreter.name;
-
-            row.className = isSelected ? 'selected' : isAssigned ? 'interpreter-assigned' : '';
+            // Show interpreters only if an event is selected, and allow assigning only for selected events
             row.innerHTML = `
-        <td>${interpreter.name}</td>
-        <td>${interpreter.fullName}</td>
-        <td>${interpreter.idName}</td>
-      `;
+                <td>${interpreter.name}</td>
+                <td>${interpreter.fullName}</td>
+                <td>${interpreter.idName}</td>
+                <td><button class="edit-int" title="Edit">✏️</button></td>
+                <td><button class="delete-int" title="Delete">🗑️</button></td>
+            `;
 
-            row.addEventListener('click', () => {
-                if (selectingAssignedFor) {
-                    // SEA edit mode: Add/remove interpreter from Assigned
-                    const names = selectingAssignedFor.input.value ? selectingAssignedFor.input.value.split(', ').filter(n => n) : [];
-                    const index = names.indexOf(interpreter.name);
-                    if (index === -1) {
-                        names.push(interpreter.name);
-                    } else {
-                        names.splice(index, 1);
+            // Edit interpreter
+            row.querySelector('.edit-int').addEventListener('click', () => {
+                elements.intInputs.name.value = interpreter.name;
+                elements.intInputs.fullName.value = interpreter.fullName;
+                elements.intInputs.idName.value = interpreter.idName;
+                editingInterpreterId = interpreter.id;
+            });
+
+            // Delete interpreter (removes from all events too)
+            row.querySelector('.delete-int').addEventListener('click', async () => {
+                interpreters = interpreters.filter(i => i.id !== interpreter.id);
+                events.forEach(ev => {
+                    if (ev.interpreterIds && ev.interpreterIds.includes(interpreter.id)) {
+                        ev.interpreterIds = ev.interpreterIds.filter(id => id !== interpreter.id);
                     }
-                    selectingAssignedFor.input.value = names.join(', ');
-
-                    const event = events.find(e => e.id === selectingAssignedFor.eventId);
-                    if (event) {
-                        event.assigned = selectingAssignedFor.input.value;
-                        const interpreters = parseInt(event.interpreters) || 0;
-                        const assignedCount = event.assigned ? event.assigned.split(', ').filter(n => n).length : 0;
-                        const eventRow = document.querySelector(`.event-row[data-id="${selectingAssignedFor.eventId}"]`);
-                        if (eventRow) {
-                            eventRow.querySelector('input[data-field="interpretersLeft"]').value = interpreters - assignedCount;
-                        }
-
-                        const calEvent = calendar.getEventById(selectingAssignedFor.eventId);
-                        if (calEvent) {
-                            calEvent.remove();
-                            event.classNames = getEventClassNames(event);
-                            calendar.addEvent(event);
-                        }
-                    }
-
-                    renderSelectedEvents();
-                    renderInterpreters();
-                    calendar.render();
-                } else {
-                    // Toggle assigning mode
-                    if (isAssigned) {
-                        assigningInterpreter = null;
-                        resetTickBoxes();
-                    } else {
-                        assigningInterpreter = { id: interpreter.id, name: interpreter.name };
-                        elements.intInputs.name.value = interpreter.name;
-                        elements.intInputs.fullName.value = interpreter.fullName;
-                        elements.intInputs.idName.value = interpreter.idName;
-                        editingInterpreterId = interpreter.id;
-                    }
-                    renderInterpreters();
-                    calendar.render();
-                }
+                });
+                await saveInterpreters(interpreters);
+                await saveEvents(events);
+                renderInterpreters();
+                renderSelectedEvents();
+                calendar.render();
             });
 
             elements.interpreterList.appendChild(row);
         });
     }
+
+    // --- INITIALIZATION ---
+
+    async function loadAllDataAndRender() {
+        await openDatabase();
+        events = await loadEvents();
+        interpreters = await loadInterpreters();
+        // Render all events into FullCalendar
+        events.forEach(ev => {
+            ev.classNames = getEventClassNames(ev);
+            calendar.addEvent(ev);
+        });
+        renderSelectedEvents();
+        renderInterpreters();
+        calendar.render();
+    }
+
+    loadAllDataAndRender();
 });


### PR DESCRIPTION
Prompt: add persistence support with indexeddb, where each event has it's interpreter list. The interpreter list should only be visible and editable when the event is selected (highlighted).

What changes?

IndexedDB functions: For CRUD operations (events & interpreters).
Event interpreter lists: Each event stores its own array of interpreter IDs (not just names).
UI logic: Interpreter lists show only for selected events.
Load/save: On page load, data is read from IndexedDB; updates are also saved back.
Serialization: Events/interpreters are stored as objects.
Key Functions Added

openDatabase(): Opens (and creates, if needed) the database and object stores.
saveEvents() / loadEvents(): For persisting events.
saveInterpreters() / loadInterpreters(): For persisting interpreters.
All CRUD actions (add/edit/delete) update IndexedDB.
Interpreter assignment per event: Each event has an interpreterIds array.

How does it work?

Events and interpreters are loaded from IndexedDB on page load.
Each event has an interpreterIds array (IDs of assigned interpreters).
When an event is selected, you see its assigned interpreters as removable chips and can add more from the available list.
All changes are immediately persisted to IndexedDB.
Deleting an interpreter removes them from all events.
